### PR TITLE
Updating .NET app image

### DIFF
--- a/Labs/Lab-2.12-DotNet/Linux/dotnet-app.yaml
+++ b/Labs/Lab-2.12-DotNet/Linux/dotnet-app.yaml
@@ -27,7 +27,7 @@ spec:
           name: appd-agent-repo
       containers:
       - name: dotnet-app
-        image: microsoft/dotnet-samples:aspnetapp
+        image: mcr.microsoft.com/dotnet/samples:aspnetapp
         imagePullPolicy: IfNotPresent
         envFrom:
            - configMapRef:


### PR DESCRIPTION
Changin the image for the .NET app from the lab. The current image from the deployment manifest doesn't exist.

```
docker pull microsoft/dotnet-samples:aspnetapp
Error response from daemon: pull access denied for microsoft/dotnet-samples, the repository does not exist or may require 'docker login': denied: requested access to the resource is denied
``

The new image comes from https://hub.docker.com/_/microsoft-dotnet-samples. Tested in the K8 cluster and works fine. 


<img width="756" alt="Screenshot 2021-09-22 at 22 40 46" src="https://user-images.githubusercontent.com/71985109/134418889-3d00a66c-72f8-4d74-af81-bb37e28f0c1c.png">

